### PR TITLE
refactor: restructure js directives for real childcare app to modularize the mock server

### DIFF
--- a/real_childcare_site/mock_server/doggy_daycare.conf
+++ b/real_childcare_site/mock_server/doggy_daycare.conf
@@ -1,6 +1,21 @@
 server {
   listen 4001;
 
+  # Old AirBnb for Dogs webapp I forgot how to maintain
+  js_import util from mock_server/util.mjs;
+  js_import listings from mock_server/doggy-daycare.mjs;
+
+  # Here we declare any variables that we want to parse out of
+  # the request path.  In this case, since I want to parse
+  # listing_id out of `/listings/:listing_id` I declare
+  # $listing_id below. Since `js_var` is only legal
+  js_var $listing_id;
+
+  # This variable is not used, but kicks off the parsing of path
+  # params lazily when they are referenced. The path params will
+  # be written to the variables declared using `js_var` above
+  js_set $path_params util.parsePathParams;
+
   location /listings {
     # This creates a template for parsing the path params
     # out of the request

--- a/real_childcare_site/nginx.conf
+++ b/real_childcare_site/nginx.conf
@@ -6,21 +6,6 @@ events {}
 http {
   default_type application/json;
 
-  # Old AirBnb for Dogs webapp I forgot how to maintain
-  js_import util from mock_server/util.mjs;
-  js_import listings from mock_server/doggy-daycare.mjs;
-
-  # Here we declare any variables that we want to parse out of
-  # the request path.  In this case, since I want to parse
-  # listing_id out of `/listings/:listing_id` I declare
-  # $listing_id below. Since `js_var` is only legal
-  js_var $listing_id;
-
-  # This variable is not used, but kicks off the parsing of path
-  # params lazily when they are referenced. The path params will
-  # be written to the variables declared using `js_var` above
-  js_set $path_params util.parsePathParams;
-
   include mock_server/doggy_daycare.conf;
 
   # import the javascript module `dogs-to-children.mjs`


### PR DESCRIPTION
# What
This PR refactors the example to take advantage of changes in njs [0.7.7](https://mailman.nginx.org/archives/list/nginx-announce@nginx.org/thread/PFUNHBJ5AERAWVPWI5L6EBBSCV7KVKCP/) that allows usage of certain `js_*` directives in more contexts.

Specifically, this moves `js_import`, `js_var`, and `js_set` that were pertinent to a mock data server out of the main `nginx.conf` file and into the `.conf` file for the mock server.

## Why is this good?

### Clarity of Code
Previous rules around `js_var`, `js_import` and `js_set` forced us to have the equivelent of a list of declared global variables at the top of the main file.  This led to two main issues:

1. In the main `nginx.conf` file, it was necessary to explain in comments **why** those directives were there because there were declarations but no obvious usage
2. In the `.conf` file where the variables are actually referenced, there's no indication where the heck they are coming from.

### Modularity
This gets us another step closer to being able to distribute njs-based modules that comprise both nginx config AND njs code (which is most non-trivial use cases).

